### PR TITLE
chore: rename crate to pprof-pyroscope-fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,8 +791,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "pprof"
-version = "0.15.0"
+name = "pprof-pyroscope-fork"
+version = "0.1500.0"
 dependencies = [
  "aligned-vec",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "pprof"
-version = "0.15.0"
+name = "pprof-pyroscope-fork"
+version = "0.1500.0"  # based on upstream pprof-rs v0.15.0
 authors = ["Yang Keao <keao.yang@yahoo.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "An internal perf tools for rust programs."
-repository = "https://github.com/tikv/pprof-rs"
-documentation = "https://docs.rs/pprof/"
+repository = "https://github.com/grafana/pprof-rs"
+documentation = "https://docs.rs/pprof-pyroscope-fork/"
 readme = "README.md"
 rust-version = "1.74.0"  # MSRV
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ documentation = "https://docs.rs/pprof-pyroscope-fork/"
 readme = "README.md"
 rust-version = "1.74.0"  # MSRV
 
+[lib]
+name = "pprof"  # keep Rust crate name as `pprof` so existing `use pprof::` code still compiles
+
 [features]
 default = ["cpp"]
 cpp = ["symbolic-demangle/cpp"]


### PR DESCRIPTION
## What

Renames the crate in `Cargo.toml` from `pprof` to `pprof-pyroscope-fork` and updates the version from `0.15.0` to `0.1500.0`.

Also updates the `repository` and `documentation` URLs to point to the Grafana fork rather than the upstream tikv repo.

## Why

This repository is Grafana's fork of [tikv/pprof-rs](https://github.com/tikv/pprof-rs). Publishing it under the same name `pprof` is ambiguous and would conflict with the upstream crate on crates.io. Renaming it to `pprof-pyroscope-fork` makes the provenance and ownership explicit.

## Version scheme

The version `0.1500.0` encodes the upstream base version (`0.15.0` → `0.1500.0`). This makes it immediately clear which upstream release the fork was branched from. Future fork-only patches increment the patch component (`0.1500.1`, `0.1500.2`, etc.), while a rebase onto a new upstream version would bump the minor component (e.g. `0.1600.0` for upstream `0.16.0`).

## Changes

- `Cargo.toml`: `name` `pprof` → `pprof-pyroscope-fork`
- `Cargo.toml`: `version` `0.15.0` → `0.1500.0` (with inline comment referencing upstream version)
- `Cargo.toml`: `repository` updated to `https://github.com/grafana/pprof-rs`
- `Cargo.toml`: `documentation` updated to `https://docs.rs/pprof-pyroscope-fork/`

No source files (`src/`, `examples/`, `benches/`) required changes — the internal `pprof::` namespace used in Rust code is determined by the library name, not the package name in `Cargo.toml`.