### PR TITLE
chore: update yanked rgb dependency from 0.8.36 to 0.8.50

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -1063,6 +1063,9 @@ name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
 name = "byteorder"
@@ -1063,9 +1063,6 @@ name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,12 +1060,9 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rgb"
-version = "0.8.36"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ec2d3e3fc7a92ced357df9cebd5a10b6fb2aa1ee797bf7e9ce2f17dffc8f59"
-dependencies = [
- "bytemuck",
-]
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 
 [[package]]
 name = "rustc-demangle"

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -80,7 +80,7 @@ impl<T: Eq> Bucket<T> {
         }
     }
 
-    pub fn iter(&self) -> BucketIterator<T> {
+    pub fn iter(&self) -> BucketIterator<'_, T> {
         BucketIterator::<T> {
             related_bucket: self,
             index: 0,

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -80,7 +80,7 @@ impl<T: Eq> Bucket<T> {
         }
     }
 
-    pub fn iter(&self) -> BucketIterator<'_, T> {
+    pub fn iter(&self) -> BucketIterator<T> {
         BucketIterator::<T> {
             related_bucket: self,
             index: 0,

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -129,11 +129,11 @@ impl Symbol {
         demangle(&String::from_utf8_lossy(self.raw_name())).into_owned()
     }
 
-    pub fn sys_name(&self) -> Cow<str> {
+    pub fn sys_name(&self) -> Cow<'_, str> {
         String::from_utf8_lossy(self.raw_name())
     }
 
-    pub fn filename(&self) -> Cow<str> {
+    pub fn filename(&self) -> Cow<'_, str> {
         self.filename
             .as_ref()
             .map(|name| name.as_os_str().to_string_lossy())

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -129,11 +129,11 @@ impl Symbol {
         demangle(&String::from_utf8_lossy(self.raw_name())).into_owned()
     }
 
-    pub fn sys_name(&self) -> Cow<'_, str> {
+    pub fn sys_name(&self) -> Cow<str> {
         String::from_utf8_lossy(self.raw_name())
     }
 
-    pub fn filename(&self) -> Cow<'_, str> {
+    pub fn filename(&self) -> Cow<str> {
         self.filename
             .as_ref()
             .map(|name| name.as_os_str().to_string_lossy())

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -198,7 +198,7 @@ impl ProfilerGuard<'_> {
     }
 
     /// Generate a report
-    pub fn report(&self) -> ReportBuilder {
+    pub fn report(&self) -> ReportBuilder<'_> {
         ReportBuilder::new(
             self.profiler,
             self.timer.as_ref().map(Timer::timing).unwrap_or_default(),

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -198,7 +198,7 @@ impl ProfilerGuard<'_> {
     }
 
     /// Generate a report
-    pub fn report(&self) -> ReportBuilder<'_> {
+    pub fn report(&self) -> ReportBuilder {
         ReportBuilder::new(
             self.profiler,
             self.timer.as_ref().map(Timer::timing).unwrap_or_default(),


### PR DESCRIPTION
## Summary

Update the `rgb` transitive dependency in `Cargo.lock` from the yanked version `0.8.36` to the stable `0.8.50`.

## What changed

- `Cargo.lock`: `rgb` bumped from `0.8.36` → `0.8.50`
- Removed the `bytemuck` entry from `rgb`'s dependency list (it became an optional dependency in `rgb 0.8.50` and is not enabled by `inferno`)

## Why

`rgb 0.8.36` was yanked from crates.io, causing the following warning during builds:

```
warning: package `rgb v0.8.36` in Cargo.lock is yanked in registry `crates-io`, consider updating to a version that is not yanked
```

## Implementation details

`rgb` is a transitive dependency pulled in by `inferno`, which declares `rgb = "^0.8.13"`. Version `0.8.50` satisfies that constraint and is the latest stable non-yanked release in the `0.8.x` series. No changes to `Cargo.toml` are required — only the resolved version in `Cargo.lock` needed updating.