### PR TITLE
chore: bump version to v0.15.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pprof"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Yang Keao <keao.yang@yahoo.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Bump the crate version from `0.15.0` to `0.15.1` in `Cargo.toml` to prepare for the next patch release.

## Changes

- `Cargo.toml`: version `0.15.0` → `0.15.1`

## Context

This patch release includes the following changes since v0.15.0:

- **framehop: remove the allocation in signal handle of framehop** (#282) — eliminates a heap allocation inside the signal handler when using the `framehop-unwinder` feature, improving signal-safety.
- **Add param to use alternate stack and restore old signal handler** (#276) — adds configuration to use an alternate signal stack and properly restores the previous signal handler on teardown.