### PR TITLE
chore: bump pprof-pyroscope-fork version to 0.1500.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "pprof-pyroscope-fork"
-version = "0.1500.0"
+version = "0.1500.1"
 dependencies = [
  "aligned-vec",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pprof-pyroscope-fork"
-version = "0.1500.0"  # based on upstream pprof-rs v0.15.0
+version = "0.1500.1"  # based on upstream pprof-rs v0.15.0
 authors = ["Yang Keao <keao.yang@yahoo.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bumps the `pprof-pyroscope-fork` crate version from `0.1500.0` to `0.1500.1` in `Cargo.toml`

## Why

Prepares the crate for the next patch release on crates.io. This follows the existing versioning scheme (`0.1500.x` based on upstream pprof-rs v0.15.0) and increments the patch component to allow publishing a new release with any accumulated fixes or changes.

## Details

- Single-file change: `Cargo.toml` version field updated
- No functional code changes; this is a release preparation commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)