### PR TITLE
Fix SIGPROF race. Use SIG_IGN instead of restoring SIG_DFL

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -505,9 +505,13 @@ impl Profiler {
     }
 
     fn unregister_signal_handler(&mut self) -> Result<()> {
-        if let Some(old_action) = self.old_sigaction.take() {
-            unsafe { signal::sigaction(signal::SIGPROF, &old_action) }?;
-        }
+        self.old_sigaction.take();
+        let ignore = signal::SigAction::new(
+            signal::SigHandler::SigIgn,
+            signal::SaFlags::empty(),
+            signal::SigSet::empty(),
+        );
+        unsafe { signal::sigaction(signal::SIGPROF, &ignore) }?;
         Ok(())
     }
 

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -505,6 +505,11 @@ impl Profiler {
     }
 
     fn unregister_signal_handler(&mut self) -> Result<()> {
+        // Use SIG_IGN instead of restoring SIG_DFL to avoid a race where a
+        // pending SIGPROF delivered between unregister and re-register kills
+        // the process (SIG_DFL for SIGPROF = terminate).
+        // See https://github.com/tikv/pprof-rs/issues/288
+        //     https://github.com/grafana/pprof-rs/pull/8
         self.old_sigaction.take();
         let ignore = signal::SigAction::new(
             signal::SigHandler::SigIgn,


### PR DESCRIPTION
## Problem

PR tikv/pprof-rs#276 changed `unregister_signal_handler()` from setting `SIG_IGN` to restoring the
previous `sigaction`. When no prior SIGPROF handler was installed (the common case), the restored
action is `SIG_DFL`, and the default disposition for SIGPROF is process termination.

During the profiler's 10-second reset cycle (used by pyroscope-rs), there is a brief window where
SIGPROF is set to SIG_DFL. Any pending SIGPROF delivered in that window kills the process with
"Profiling timer expired".

Full analysis: https://github.com/tikv/pprof-rs/issues/288

## Fix

Set `SIG_IGN` instead of restoring `SIG_DFL`. This matches the original pprof 0.15.0 behavior
before PR #276.