### PR TITLE
fix: enforce conventional commit format for PR titles

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,30 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title follows conventional commits
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Check if PR title starts with feat:, fix:, feat!:, or fix!:
+          if echo "$PR_TITLE" | grep -qE '^(feat|fix)(!)?:'; then
+            echo "✓ PR title follows conventional commits format"
+            exit 0
+          else
+            echo "✗ PR title must start with 'feat:', 'fix:', 'feat!:', or 'fix!:'"
+            echo "  Current title: $PR_TITLE"
+            echo ""
+            echo "Examples:"
+            echo "  feat: add new feature"
+            echo "  fix: resolve bug in profiler"
+            echo "  feat!: breaking change to API"
+            echo "  fix!: breaking fix"
+            exit 1
+          fi

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -13,18 +13,20 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # Check if PR title starts with feat:, fix:, feat!:, or fix!:
-          if echo "$PR_TITLE" | grep -qE '^(feat|fix)(!)?:'; then
+          # Check if PR title starts with allowed conventional commit types
+          if echo "$PR_TITLE" | grep -qE '^(feat|fix|ci|chore)(!)?:'; then
             echo "✓ PR title follows conventional commits format"
             exit 0
           else
-            echo "✗ PR title must start with 'feat:', 'fix:', 'feat!:', or 'fix!:'"
+            echo "✗ PR title must start with 'feat:', 'fix:', 'ci:', 'chore:', or any with '!' for breaking changes"
             echo "  Current title: $PR_TITLE"
             echo ""
             echo "Examples:"
-            echo "  feat: add new feature"
-            echo "  fix: resolve bug in profiler"
-            echo "  feat!: breaking change to API"
-            echo "  fix!: breaking fix"
+            echo "  feat: add new feature (triggers minor version bump)"
+            echo "  fix: resolve bug in profiler (triggers patch version bump)"
+            echo "  ci: update GitHub Actions workflows (triggers patch version bump)"
+            echo "  chore: update dependencies (triggers patch version bump)"
+            echo "  feat!: breaking change to API (triggers major version bump)"
+            echo "  fix!: breaking fix (triggers major version bump)"
             exit 1
           fi

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -14,19 +14,26 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Check if PR title starts with allowed conventional commit types
-          if echo "$PR_TITLE" | grep -qE '^(feat|fix|ci|chore)(!)?:'; then
+          if echo "$PR_TITLE" | grep -qE '^(feat|fix|perf|revert|docs|style|chore|refactor|test|build|ci)(!)?:'; then
             echo "✓ PR title follows conventional commits format"
             exit 0
           else
-            echo "✗ PR title must start with 'feat:', 'fix:', 'ci:', 'chore:', or any with '!' for breaking changes"
+            echo "✗ PR title must use conventional commit format: <type>: <description>"
             echo "  Current title: $PR_TITLE"
             echo ""
-            echo "Examples:"
-            echo "  feat: add new feature (triggers minor version bump)"
-            echo "  fix: resolve bug in profiler (triggers patch version bump)"
-            echo "  ci: update GitHub Actions workflows (triggers patch version bump)"
-            echo "  chore: update dependencies (triggers patch version bump)"
-            echo "  feat!: breaking change to API (triggers major version bump)"
-            echo "  fix!: breaking fix (triggers major version bump)"
+            echo "Allowed types:"
+            echo "  feat:     new feature (minor bump)"
+            echo "  fix:      bug fix (patch bump)"
+            echo "  perf:     performance improvement (patch bump)"
+            echo "  docs:     documentation (patch bump)"
+            echo "  refactor: code refactoring (patch bump)"
+            echo "  test:     tests (patch bump)"
+            echo "  ci:       CI/CD changes (patch bump)"
+            echo "  chore:    maintenance (patch bump)"
+            echo "  build:    build system (patch bump)"
+            echo "  style:    code style (patch bump)"
+            echo "  revert:   revert changes (patch bump)"
+            echo ""
+            echo "Add ! for breaking changes (major bump): feat!:, fix!:, etc."
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,47 +2,11 @@
 
 ## Pull Request Titles
 
-When creating pull requests, always use conventional commit format in the title. The PR title will become the commit message when squash-merged, so it must follow this format:
+Use conventional commit format: `<type>: <description>`
 
-### Format
-
-```
-<type>[optional !]: <description>
-```
-
-### Allowed Types
-
-- **`feat:`** - New feature (triggers **minor** version bump, e.g., 0.1.0 → 0.2.0)
-  - Example: `feat: add support for custom profiling intervals`
-
-- **`fix:`** - Bug fix (triggers **patch** version bump, e.g., 0.1.0 → 0.1.1)
-  - Example: `fix: resolve SIGPROF race condition in profiler`
-
-- **`ci:`** - CI/CD changes (triggers **patch** version bump)
-  - Example: `ci: add release-please workflow`
-
-- **`chore:`** - Maintenance tasks (triggers **patch** version bump)
-  - Example: `chore: update dependencies`
-
-### Breaking Changes
-
-Add `!` after the type for breaking changes (triggers **major** version bump, e.g., 0.1.0 → 1.0.0):
-- `feat!: redesign profiler API`
-- `fix!: change default profiling frequency`
-
-### Guidelines
-
-1. **Keep titles concise** - Under 70 characters
-2. **Use imperative mood** - "add feature" not "added feature"
-3. **No period at the end** - `feat: add feature` not `feat: add feature.`
-4. **Lowercase after colon** - `feat: add feature` not `feat: Add feature`
-5. **PR title validation** - CI will enforce these rules automatically
-
-### Why This Matters
-
-- PR titles become commit messages when squash-merged
-- [release-please](https://github.com/googleapis/release-please) uses these to:
-  - Automatically generate changelogs
-  - Determine version bumps
-  - Create release PRs
-- Consistent format makes the git history readable and professional
+Allowed types:
+- `feat:` - new feature
+- `fix:` - bug fix
+- `ci:` - CI/CD changes
+- `chore:` - maintenance
+- Add `!` for breaking changes: `feat!:`, `fix!:`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,13 @@ Use conventional commit format: `<type>: <description>`
 Allowed types:
 - `feat:` - new feature
 - `fix:` - bug fix
+- `perf:` - performance improvement
+- `docs:` - documentation
+- `refactor:` - code refactoring
+- `test:` - tests
 - `ci:` - CI/CD changes
 - `chore:` - maintenance
+- `build:` - build system
+- `style:` - code style
+- `revert:` - revert changes
 - Add `!` for breaking changes: `feat!:`, `fix!:`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# Claude Instructions for pprof-rs
+
+## Pull Request Titles
+
+When creating pull requests, always use conventional commit format in the title. The PR title will become the commit message when squash-merged, so it must follow this format:
+
+### Format
+
+```
+<type>[optional !]: <description>
+```
+
+### Allowed Types
+
+- **`feat:`** - New feature (triggers **minor** version bump, e.g., 0.1.0 → 0.2.0)
+  - Example: `feat: add support for custom profiling intervals`
+
+- **`fix:`** - Bug fix (triggers **patch** version bump, e.g., 0.1.0 → 0.1.1)
+  - Example: `fix: resolve SIGPROF race condition in profiler`
+
+- **`ci:`** - CI/CD changes (triggers **patch** version bump)
+  - Example: `ci: add release-please workflow`
+
+- **`chore:`** - Maintenance tasks (triggers **patch** version bump)
+  - Example: `chore: update dependencies`
+
+### Breaking Changes
+
+Add `!` after the type for breaking changes (triggers **major** version bump, e.g., 0.1.0 → 1.0.0):
+- `feat!: redesign profiler API`
+- `fix!: change default profiling frequency`
+
+### Guidelines
+
+1. **Keep titles concise** - Under 70 characters
+2. **Use imperative mood** - "add feature" not "added feature"
+3. **No period at the end** - `feat: add feature` not `feat: add feature.`
+4. **Lowercase after colon** - `feat: add feature` not `feat: Add feature`
+5. **PR title validation** - CI will enforce these rules automatically
+
+### Why This Matters
+
+- PR titles become commit messages when squash-merged
+- [release-please](https://github.com/googleapis/release-please) uses these to:
+  - Automatically generate changelogs
+  - Determine version bumps
+  - Create release PRs
+- Consistent format makes the git history readable and professional

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,21 @@
       "release-type": "rust",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "extra-files": [],
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance Improvements"},
+        {"type": "revert", "section": "Reverts"},
+        {"type": "docs", "section": "Documentation"},
+        {"type": "style", "section": "Styles"},
+        {"type": "chore", "section": "Miscellaneous Chores"},
+        {"type": "refactor", "section": "Code Refactoring"},
+        {"type": "test", "section": "Tests"},
+        {"type": "build", "section": "Build System"},
+        {"type": "ci", "section": "Continuous Integration"}
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to validate PR titles
- Ensures PRs follow conventional commit format: `feat:`, `fix:`, `feat!:`, or `fix!:`
- This helps release-please properly recognize changes for changelog generation

## Why
Release-please only creates release PRs for user-facing commits (feat/fix). By enforcing this format at the PR level, we ensure all merged changes are properly tracked for releases.

## Test plan
- [ ] Open a PR with invalid title (e.g., "add feature") - workflow should fail
- [ ] Open a PR with valid title (e.g., "feat: add feature") - workflow should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)