### PR TITLE
chore: update framehop to 0.16.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
     name: Run release-please
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
-          toolchain: stable
+          toolchain: 1.88.0
 
       - name: Authenticate with crates.io
         id: auth

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
-          toolchain: "1.74.0"
+          toolchain: "1.88.0"
           components: rustfmt, clippy
 
       - name: Install protobuf compiler
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        toolchain: [stable, nightly, 1.74.0]
+        toolchain: [stable, nightly, 1.88.0]
         target:
           [
             x86_64-unknown-linux-gnu,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,12 +139,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,14 +434,14 @@ dependencies = [
 
 [[package]]
 name = "framehop"
-version = "0.13.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bdf491caf8284489b65c99366d0f88393709b8214e4ccff2f55d9892da7713"
+checksum = "6f54fe4785e899d4d6f43793b151c63c5647240fc630b005509d2614a939f693"
 dependencies = [
  "arrayvec",
  "cfg-if",
  "fallible-iterator",
- "gimli 0.31.1",
+ "gimli 0.33.0",
  "macho-unwind-info",
  "pe-unwind-info",
 ]
@@ -481,11 +475,10 @@ checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
- "fallible-iterator",
  "stable_deref_trait",
 ]
 
@@ -741,15 +734,15 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "pe-unwind-info"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fe3d7d11dde0fd142bf734ae5d645a4c62ede7c188bccc73dec5082359ff84"
+checksum = "97f6fccfd2d9d2df765ca23ff85fe5cc437fb0e6d3e164e4d3cbe09d14780c93"
 dependencies = [
  "arrayvec",
  "bitflags 2.4.0",
- "thiserror 1.0.69",
- "zerocopy 0.7.35",
- "zerocopy-derive 0.7.35",
+ "thiserror 2.0.12",
+ "zerocopy 0.8.25",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -1492,7 +1485,6 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
  "zerocopy-derive 0.7.35",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "An internal perf tools for rust programs."
 repository = "https://github.com/grafana/pprof-rs"
 documentation = "https://docs.rs/pprof-pyroscope-fork/"
 readme = "README.md"
-rust-version = "1.74.0"  # MSRV
+rust-version = "1.88.0"  # MSRV
 
 [lib]
 name = "pprof"  # keep Rust crate name as `pprof` so existing `use pprof::` code still compiles
@@ -49,7 +49,7 @@ criterion = {version = "0.5", optional = true}
 aligned-vec = "0.6"
 
 # framehop unwinder dependencies
-framehop = { version = "0.13", optional = true }
+framehop = { version = "0.16", optional = true }
 memmap2 = { version = "0.5.5", optional = true }
 object = { version = "0.29.0", optional = true }
 arc-swap = { version = "1.7.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Unit tests have been added to guarantee there is no `malloc` in sample functions
 
 ## Minimum Supported Rust Version
 
-Rust 1.74 or higher.
+Rust 1.88 or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be done with a minor version bump.
 

--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,7 @@ fn generate_protobuf() {
     cg.out_dir(&out_dir).run().unwrap();
 
     // Optionally, write a mod.rs file for module inclusion
-    let mut f = std::fs::File::create(format!("{}/mod.rs", out_dir)).unwrap();
+    let mut f = std::fs::File::create(format!("{out_dir}/mod.rs")).unwrap();
     write!(f, "pub mod profile;").unwrap();
 }
 
@@ -37,9 +37,9 @@ fn generate_prost() {
     io::copy(&mut proto_file, &mut hasher).unwrap();
     let mut hex = String::new();
     for b in hasher.finalize() {
-        write!(&mut hex, "{:x}", b).unwrap();
+        write!(&mut hex, "{b:x}").unwrap();
     }
-    let hash_comment = format!("// {}  proto/profile.proto", hex);
+    let hash_comment = format!("// {hex}  proto/profile.proto");
 
     let first_line = File::open(PRE_GENERATED_PATH)
         .and_then(|f| {
@@ -57,7 +57,7 @@ fn generate_prost() {
             .unwrap();
         // Prepend the hash comment to the generated file.
         let generated = fs::read_to_string(PRE_GENERATED_PATH).unwrap();
-        let with_hex = format!("{}\n\n{}", hash_comment, generated);
+        let with_hex = format!("{hash_comment}\n\n{generated}");
         fs::write(PRE_GENERATED_PATH, with_hex).unwrap();
     }
 }

--- a/examples/flamegraph.rs
+++ b/examples/flamegraph.rs
@@ -95,12 +95,12 @@ fn main() {
         }
     }
 
-    println!("Prime numbers: {}", v);
+    println!("Prime numbers: {v}");
 
     if let Ok(report) = guard.report().build() {
         let file = File::create("flamegraph.svg").unwrap();
         report.flamegraph(file).unwrap();
 
-        println!("report: {:?}", &report);
+        println!("report: {report:?}");
     };
 }

--- a/examples/multithread.rs
+++ b/examples/multithread.rs
@@ -88,7 +88,7 @@ fn main() {
 
     loop {
         if let Ok(report) = guard.report().build() {
-            println!("{:?}", report);
+            println!("{report:?}");
         };
         std::thread::sleep(std::time::Duration::from_secs(1))
     }

--- a/examples/multithread_flamegraph.rs
+++ b/examples/multithread_flamegraph.rs
@@ -93,7 +93,7 @@ fn main() {
         let file = File::create("flamegraph.svg").unwrap();
         report.flamegraph(file).unwrap();
 
-        println!("{:?}", report);
+        println!("{report:?}");
     };
 
     //    pprof::PROFILER.lock().unwrap().stop();

--- a/examples/post_processor.rs
+++ b/examples/post_processor.rs
@@ -95,7 +95,7 @@ fn main() {
             })
             .build()
         {
-            println!("{:?}", report);
+            println!("{report:?}");
         };
         std::thread::sleep(std::time::Duration::from_secs(1))
     }

--- a/examples/prime_number.rs
+++ b/examples/prime_number.rs
@@ -54,10 +54,10 @@ fn main() {
             }
         }
 
-        println!("Prime numbers: {}", v);
+        println!("Prime numbers: {v}");
 
         if let Ok(report) = guard.report().build() {
-            println!("{:?}", report);
+            println!("{report:?}");
         };
     }
 }

--- a/examples/profile_proto_with_protobuf_codec.rs
+++ b/examples/profile_proto_with_protobuf_codec.rs
@@ -97,7 +97,7 @@ fn main() {
         }
     }
 
-    println!("Prime numbers: {}", v);
+    println!("Prime numbers: {v}");
 
     if let Ok(report) = guard.report().build() {
         let mut file = File::create("profile.pb").unwrap();
@@ -107,6 +107,6 @@ fn main() {
         profile.write_to_vec(&mut content).unwrap();
         file.write_all(&content).unwrap();
 
-        println!("report: {:?}", report);
+        println!("report: {report:?}");
     };
 }

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -252,7 +252,7 @@ impl Debug for Frames {
         for frame in self.frames.iter() {
             write!(f, "FRAME: ")?;
             for symbol in frame.iter() {
-                write!(f, "{} -> ", symbol)?;
+                write!(f, "{symbol} -> ")?;
             }
         }
         write!(f, "THREAD: ")?;

--- a/src/report.rs
+++ b/src/report.rs
@@ -167,7 +167,7 @@ impl<'a> ReportBuilder<'a> {
 impl Debug for Report {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         for (key, val) in self.data.iter() {
-            write!(f, "{:?} {}", key, val)?;
+            write!(f, "{key:?} {val}")?;
             writeln!(f)?;
         }
 
@@ -208,12 +208,12 @@ mod flamegraph {
 
                     for frame in key.frames.iter().rev() {
                         for symbol in frame.iter().rev() {
-                            write!(&mut line, "{};", symbol).unwrap();
+                            write!(&mut line, "{symbol};").unwrap();
                         }
                     }
 
                     line.pop().unwrap_or_default();
-                    write!(&mut line, " {}", value).unwrap();
+                    write!(&mut line, " {value}").unwrap();
 
                     line
                 })


### PR DESCRIPTION
## Summary
Update `framehop` to 0.16.0 and raise the crate MSRV and CI toolchains to Rust 1.88 so the `framehop-unwinder` feature remains buildable.

## Context
The latest `framehop` release now depends on `gimli` 0.33, which requires Rust 1.88. Keeping this crate on the latest `framehop` therefore also requires raising the declared MSRV and aligning CI and release publishing to the same compiler version.

## Changes
- Bumped the optional `framehop` dependency from `0.13` to `0.16`
- Refreshed `Cargo.lock` for `framehop` 0.16.0 and its transitive updates
- Raised `rust-version` in the crate manifest from 1.74.0 to 1.88.0
- Updated CI and release workflows to install and build with Rust 1.88.0 where the repo previously pinned 1.74.0 or `stable`
- Updated the README MSRV note to match the manifest

## Key Implementation Details
`framehop` 0.16.0 itself did not require any source changes in the crate’s unwinder integration. The only compatibility issue was toolchain level: `gimli` 0.33 requires Rust 1.88, so the manifest, CI, and release workflow were updated together.

## Testing
- `cargo test --lib --tests --no-default-features --features framehop-unwinder -- --test-threads=1`

This run succeeds for the updated framehop-specific unwind path except for `frames::tests::demangle_cpp`, which also fails on clean `origin/master` under the same single-threaded invocation and is therefore pre-existing.

## Links
- framehop: https://crates.io/crates/framehop/0.16.0
- gimli: https://crates.io/crates/gimli/0.33.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to raising MSRV to Rust 1.88 and updating CI/release toolchains, which can break downstream builds pinned to older compilers. Dependency bumps (notably `framehop`/`gimli`) may also introduce platform-specific unwind/build regressions.
> 
> **Overview**
> Updates the optional `framehop-unwinder` stack unwinding dependency by bumping `framehop` to `0.16` (and refreshing `Cargo.lock` for new transitive versions like `gimli`).
> 
> Raises the crate MSRV to Rust `1.88.0` and aligns CI/release workflows to install/build/publish with `1.88.0` (including pinning the `release-please` action by commit). Also includes small formatting-only changes (Rust format string modernization) in `build.rs`, examples, and `Debug` output implementations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82f654dcaef57a0fa72a98a840875ab8f9d14fd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->