### PR TITLE
test: restrict sigprof_race to framehop-unwinder feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,5 +98,10 @@ name = "addr_validate"
 path = "benches/addr_validate.rs"
 harness = false
 
+[[test]]
+name = "sigprof_race"
+path = "tests/sigprof_race.rs"
+required-features = ["framehop-unwinder"]
+
 [package.metadata.docs.rs]
 all-features = true

--- a/tests/sigprof_race.rs
+++ b/tests/sigprof_race.rs
@@ -1,3 +1,9 @@
+#![cfg(all(
+    feature = "framehop-unwinder",
+    any(target_arch = "x86_64", target_arch = "aarch64"),
+    any(target_os = "linux", target_os = "macos"),
+))]
+
 // Regression test for the SIGPROF race condition fixed in:
 // https://github.com/grafana/pprof-rs/commit/978d3aa248fa19be6cc6f8488f1472cea98bf8a2
 //
@@ -7,7 +13,13 @@
 // (during rapid start/stop cycles), the process crashes.
 //
 // Run with:
-//   cargo test --test sigprof_race -- --test-threads 1
+//   cargo test --features framehop-unwinder --test sigprof_race -- --test-threads 1
+//
+// This test only compiles under the framehop unwinder. The default
+// backtrace-rs unwinder on macOS has separate async-signal-safety issues
+// (libunwind/dyld reentrancy) that mask the signal-handler-registration
+// race this test is meant to catch. See
+// https://github.com/grafana/pyroscope-pprof-rs/issues/28.
 //
 // Without the fix, this test crashes the process with SIGPROF.
 // With the fix (SIG_IGN instead of SIG_DFL restore), it completes cleanly.


### PR DESCRIPTION
Fixes https://github.com/grafana/pyroscope-pprof-rs/issues/28. The sigprof_race integration test is now only compiled when the framehop-unwinder feature is enabled, via both a \`required-features\` entry in \`Cargo.toml\` and a defense-in-depth crate-level \`#![cfg(..)]\` that mirrors the framehop selection cfg in \`src/backtrace/mod.rs\`. The SIGPROF signal-handler registration race this test guards against lives in unwinder-agnostic code (\`src/profiler.rs\`), so a single unwinder is sufficient to catch regressions; the default backtrace-rs unwinder on macOS has separate libunwind/dyld async-signal-safety issues that mask the race the test is designed to detect. CI already exercises framehop on every matrix cell via the existing \`Run cargo test framehop\` step in \`.github/workflows/rust.yml:142-143\`, so no workflow changes are needed. This unblocks macOS CI, which currently crashes with SIGBUS in the default-unwinder step before the framehop step gets a chance to run.