### PR TITLE
fix: address ASan-reported overflows in addr_validate and HashCounter::iter

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
     name: Run release-please
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
     name: Run release-please
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -141,3 +141,36 @@ jobs:
 
       - name: Run cargo test framehop
         run: cargo test --features flamegraph,protobuf-codec,framehop-unwinder --target ${{ matrix.target }} -- --test-threads 1
+
+  asan:
+    name: Test (AddressSanitizer)
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-Zsanitizer=address"
+      RUSTDOCFLAGS: "-Zsanitizer=address"
+      ASAN_OPTIONS: "detect_leaks=0"
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        with:
+          toolchain: nightly
+          target: x86_64-unknown-linux-gnu
+          components: rust-src
+
+      - name: Install protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Run cargo test prost (ASan)
+        run: cargo test --features flamegraph,prost-codec --target x86_64-unknown-linux-gnu -- --test-threads 1
+
+      - name: Run cargo test protobuf (ASan)
+        run: cargo test --features flamegraph,protobuf-codec --target x86_64-unknown-linux-gnu -- --test-threads 1
+
+      - name: Run cargo test framehop (ASan)
+        run: cargo test --features flamegraph,protobuf-codec,framehop-unwinder --target x86_64-unknown-linux-gnu -- --test-threads 1

--- a/benches/addr_validate.rs
+++ b/benches/addr_validate.rs
@@ -5,21 +5,21 @@ use pprof::validate;
 
 fn bench_validate_addr(c: &mut Criterion) {
     c.bench_function("validate stack addr", |b| {
-        let stack_addrs = [0; 100];
+        let stack_addrs: [u128; 100] = [0; 100];
 
         b.iter(|| {
             stack_addrs.iter().for_each(|item| {
-                validate(item as *const _ as *const libc::c_void);
+                validate(item);
             })
         })
     });
 
     c.bench_function("validate heap addr", |b| {
-        let heap_addrs = vec![0; 100];
+        let heap_addrs: Vec<u128> = vec![0; 100];
 
         b.iter(|| {
             heap_addrs.iter().for_each(|item| {
-                validate(item as *const _ as *const libc::c_void);
+                validate(item);
             })
         })
     });

--- a/src/addr_validate.rs
+++ b/src/addr_validate.rs
@@ -79,6 +79,7 @@ pub fn validate<T>(addr: *const T) -> bool {
             "validate<T>(): T must be at least two pointer sizes wide",
         );
     }
+    #[allow(clippy::let_unit_value)]
     let _: () = AssertSize::<T>::OK;
 
     // it's a short circuit for null pointer, as it'll give an error in

--- a/src/addr_validate.rs
+++ b/src/addr_validate.rs
@@ -68,7 +68,19 @@ fn open_pipe() -> nix::Result<()> {
 // if the second argument of `write(ptr, buf)` is not a valid address, the
 // `write()` will return an error the error number should be `EFAULT` in most
 // cases, but we regard all errors (except EINTR) as a failure of validation
-pub fn validate(addr: *const libc::c_void) -> bool {
+//
+// `validate` reads exactly `2 * size_of::<*const c_void>()` bytes from `addr`,
+// so `T` must be at least that wide. The bound is enforced at compile time.
+pub fn validate<T>(addr: *const T) -> bool {
+    struct AssertSize<T>(core::marker::PhantomData<T>);
+    impl<T> AssertSize<T> {
+        const OK: () = assert!(
+            size_of::<T>() >= 2 * size_of::<*const libc::c_void>(),
+            "validate<T>(): T must be at least two pointer sizes wide",
+        );
+    }
+    let _: () = AssertSize::<T>::OK;
+
     // it's a short circuit for null pointer, as it'll give an error in
     // `std::slice::from_raw_parts` if the pointer is null.
     if addr.is_null() {
@@ -112,23 +124,23 @@ mod test {
 
     #[test]
     fn validate_stack() {
-        let i = 0;
+        let i: u128 = 0;
 
-        assert!(validate(&i as *const _ as *const libc::c_void));
+        assert!(validate(&i));
     }
 
     #[test]
     fn validate_heap() {
-        let vec = vec![0; 1000];
+        let vec: Vec<u128> = vec![0; 1000];
 
         for i in vec.iter() {
-            assert!(validate(i as *const _ as *const libc::c_void));
+            assert!(validate(i));
         }
     }
 
     #[test]
     fn failed_validate() {
-        assert!(!validate(std::ptr::null::<libc::c_void>()));
-        assert!(!validate(-1_i32 as usize as *const libc::c_void))
+        assert!(!validate(std::ptr::null::<u128>()));
+        assert!(!validate(-1_i32 as usize as *const u128))
     }
 }

--- a/src/backtrace/frame_pointer.rs
+++ b/src/backtrace/frame_pointer.rs
@@ -111,7 +111,7 @@ impl super::Trace for Trace {
                 break;
             }
 
-            if !validate(frame_pointer as *const libc::c_void) {
+            if !validate(frame_pointer) {
                 break;
             }
             last_frame_pointer = frame_pointer;

--- a/src/backtrace/framehop_unwinder.rs
+++ b/src/backtrace/framehop_unwinder.rs
@@ -117,7 +117,7 @@ impl FramehopUnwinder {
 
 fn read_stack(addr: u64) -> Result<u64, ()> {
     let aligned_addr = addr & !0b111;
-    if crate::addr_validate::validate(aligned_addr as _) {
+    if crate::addr_validate::validate(aligned_addr as *const u128) {
         Ok(unsafe { (aligned_addr as *const u64).read() })
     } else {
         Err(())

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -145,13 +145,7 @@ impl<T: Hash + Eq> HashCounter<T> {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Entry<T>> {
-        let mut iter: Box<dyn Iterator<Item = &Entry<T>>> =
-            Box::new(self.buckets[0].iter().chain(std::iter::empty()));
-        for bucket in self.buckets[1..].iter() {
-            iter = Box::new(iter.chain(bucket.iter()));
-        }
-
-        iter
+        self.buckets.iter().flat_map(|bucket| bucket.iter())
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #38 and #39 — both surfaced by running the test suite under AddressSanitizer.

- **#39** — `HashCounter::iter()` built a 4096-deep ladder of `Box<dyn Iterator>` + `Chain` whose `size_hint()` recursed through every level and stack-overflowed; replaced with `flat_map` (O(1) deep).
- **#38** — `validate()` always reads `2 * size_of::<*const c_void>()` bytes, but its `*const c_void` signature let test and bench callers pass an `i32` and over-read into ASan redzones. Tightened the API to `validate<T>(*const T)` with a compile-time assertion that `T` is at least two pointer sizes wide; updated the two real call sites (`frame_pointer.rs`, `framehop_unwinder.rs`), the tests, and the criterion bench.
- Added a new `asan` CI job (Ubuntu nightly, `RUSTFLAGS=-Zsanitizer=address`, `ASAN_OPTIONS=detect_leaks=0`) that runs the test suite across the prost-codec, protobuf-codec, and framehop-unwinder feature combos so this class of bug is caught going forward.

## Test plan

- [x] `cargo test --lib` (prost-codec, protobuf-codec, framehop-unwinder) — 13/13 each
- [x] `RUSTFLAGS="-Zsanitizer=address" cargo +nightly test --target aarch64-apple-darwin --lib` — clean, no ASan reports
- [x] Verified compile-time assertion fires when `T` is too small
- [x] `cargo fmt --check` and `cargo clippy` clean for prost-codec / protobuf-codec
- [ ] New `asan` CI job runs and passes on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches unsafe pointer validation used during stack unwinding and changes a public-ish API signature, which could affect downstream callers or platform-specific behavior, though changes are localized and now better guarded by compile-time checks and ASan CI.
> 
> **Overview**
> Fixes ASan-reported memory issues by making `addr_validate::validate` generic (`validate<T>(*const T)`) with a compile-time size assertion, and updating all call sites/tests/benchmarks to pass suitably-sized pointer types instead of `*const c_void` casts.
> 
> Prevents iterator stack overflow in `HashCounter::iter()` by replacing the boxed `chain` ladder with a simple `flat_map` over buckets.
> 
> CI is updated to run a dedicated nightly AddressSanitizer test job (prost/protobuf/framehop feature combos), and the `release-please` GitHub Action is bumped to v5 (pinned SHA).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df6a2d771252432535b3c4cb882692232017a698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->