### PR TITLE
ci: restrict pr-title-check workflow permissions to contents:read

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   check-title:
     name: Validate PR Title


### PR DESCRIPTION
The pr-title-check workflow currently has no top-level `permissions:` block, so it inherits the repository default `GITHUB_TOKEN` scopes for every job. The workflow only reads the PR title from the event payload and does not need any token access.

This adds `permissions: contents: read` so the token is minimally scoped.